### PR TITLE
Fix: don’t assume persp-mode is enabled

### DIFF
--- a/persp-projectile.el
+++ b/persp-projectile.el
@@ -56,7 +56,7 @@ project, this advice creates a new perspective for that project."
   `(defadvice ,func-name (before projectile-create-perspective-after-switching-projects activate)
      "Create a dedicated perspective for current project's window after switching projects."
      (let ((project-name (projectile-project-name)))
-       (when (projectile-project-p)
+       (when (and persp-mode projectile-project-p)
          (persp-switch project-name)))))
 
 (projectile-persp-bridge projectile-dired)


### PR DESCRIPTION
Invoking ‘persp-switch’ when not in persp-mode results in a run-time error when
using perspective-20160609.1444.