### PR TITLE
Read perspectives-hash from the frame

### DIFF
--- a/persp-projectile.el
+++ b/persp-projectile.el
@@ -76,7 +76,7 @@ perspective."
   (interactive (list (projectile-completing-read "Switch to project: "
                                                  (projectile-relevant-known-projects))))
   (let* ((name (file-name-nondirectory (directory-file-name project-to-switch)))
-         (persp (gethash name perspectives-hash)))
+         (persp (gethash name (perspectives-hash))))
     (cond
      ;; project-specific perspective already exists
      ((and persp (not (equal persp persp-curr)))


### PR DESCRIPTION
Perspective-el will likely move every variable to be a frame variable because
of the future deprecation of make-variable-frame-local in Emacs 26 so this
packages needs to follow suit.