### PR TITLE
Fix Symbol’s value as variable is void: projectile-project-p

### DIFF
--- a/persp-projectile.el
+++ b/persp-projectile.el
@@ -56,7 +56,7 @@ project, this advice creates a new perspective for that project."
   `(defadvice ,func-name (before projectile-create-perspective-after-switching-projects activate)
      "Create a dedicated perspective for current project's window after switching projects."
      (let ((project-name (projectile-project-name)))
-       (when (and persp-mode projectile-project-p)
+       (when (and persp-mode (projectile-project-p))
          (persp-switch project-name)))))
 
 (projectile-persp-bridge projectile-dired)


### PR DESCRIPTION
When I use `C-c p p` with `persp-projectile`, it emits message `Symbol’s value as variable is void: projectile-project-p`.

It's from not calling `projectile-project-p`, so I change the code to call it.
