### PR TITLE
Fix the persp exists but not match with projectile-name

### DIFF
--- a/persp-projectile.el
+++ b/persp-projectile.el
@@ -82,6 +82,10 @@ perspective."
      ;; project-specific perspective already exists
      ((and persp (not (equal persp (persp-curr))))
       (persp-switch name))
+     ;; persp exists but not match with projectile-name
+     ((and persp (not (equal persp name)))
+      (persp-switch name)
+      (projectile-switch-project-by-name project-to-switch))
      ;; project-specific perspective doesn't exist
      ((not persp)
       (let ((frame (selected-frame)))


### PR DESCRIPTION
Hi,
I'm using persp-projectile, and I usually see the persp not match with projectile-name.
Because when I was on a projectile had the same name with persp, I went to another project by `find-files` (you known, the project does not exist in projectile caches), this is why I would like to send this PR.

Could you please consider the pull request?
Thank you!